### PR TITLE
refactor: clean up enum ref generation

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -12,7 +12,8 @@ import {
   TInterface,
   TIntersection,
   TNamedInterface,
-  TUnion
+  TUnion,
+  TTypeReference
 } from './types/AST'
 import {log, toSafeString} from './utils'
 
@@ -282,6 +283,8 @@ function generateRawType(ast: AST, options: Options): string {
       return generateSetOperation(ast, options)
     case 'CUSTOM_TYPE':
       return ast.params
+    case 'TYPE_REFERENCE':
+      return generateEnumReference(ast)
   }
 }
 
@@ -335,6 +338,11 @@ function generateStandaloneEnum(ast: TEnum, options: Options): string {
     '\n' +
     '}'
   )
+}
+
+function generateEnumReference(ast: TTypeReference): string {
+  const [parent, key] = ast.params
+  return `${toSafeString(parent.standaloneName)}.${key.keyName}`
 }
 
 function generateStandaloneInterface(ast: TNamedInterface, options: Options): string {

--- a/src/types/AST.ts
+++ b/src/types/AST.ts
@@ -4,7 +4,7 @@ export type AST_TYPE = AST['type']
 
 export type AST = TAny | TArray | TBoolean | TEnum | TInterface | TNamedInterface
   | TIntersection | TLiteral | TNumber | TNull | TObject | TReference
-  | TString | TTuple | TUnion | TCustomType
+  | TString | TTuple | TUnion | TCustomType | TTypeReference
 
 export interface AbstractAST {
   comment?: string
@@ -49,6 +49,12 @@ export interface TEnum extends AbstractAST {
 export interface TEnumParam {
   ast: AST
   keyName: string
+}
+
+export interface TTypeReference extends AbstractAST {
+  type: 'TYPE_REFERENCE'
+  // Note: this can be expanded for other advanced type referencing, to reduce duplication
+  params: [TEnum, TEnumParam]
 }
 
 export interface TInterface extends AbstractAST {


### PR DESCRIPTION
There was code generation hidden inside of the parser, which needed to be cleaned up and moved to the proper location.