### PR TITLE
feat: support circular schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "npm run clean && mkdir dist && npm run build:browser && npm run build:server",
     "build:browser": "browserify src/index.ts -s jstt -p tsify > dist/bundle.js",
-    "build:server": "tsc -d",
+    "build:server": "tsc -d && shx chmod +x ./dist/src/cli.js",
     "clean": "shx rm -rf dist",
     "lint": "eslint src/*.ts test/*.ts",
     "tdd": "concurrently -r -p '' -k 'npm run watch' 'npm run watch:test'",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,17 @@
 #!/usr/bin/env node
 
+try {
+  const sms = require('source-map-support')
+  sms.install()
+} catch {}
+
 import {whiteBright} from 'cli-color'
 import minimist = require('minimist')
 import {readFile, writeFile, existsSync, lstatSync, readdirSync} from 'mz/fs'
 import * as mkdirp from 'mkdirp'
 import * as _glob from 'glob'
 import isGlob = require('is-glob')
+import * as _ from 'lodash'
 import {promisify} from 'util'
 import {join, resolve, dirname, basename} from 'path'
 import stdin = require('stdin')
@@ -20,7 +26,8 @@ main(
     alias: {
       help: ['h'],
       input: ['i'],
-      output: ['o']
+      output: ['o'],
+      verbose: ['v']
     }
   })
 )
@@ -31,8 +38,22 @@ async function main(argv: minimist.ParsedArgs) {
     process.exit(0)
   }
 
+  if (argv.verbose) {
+    process.env.VERBOSE = '1'
+  }
+
   const argIn: string = argv._[0] || argv.input
   const argOut: string | undefined = argv._[1] || argv.output // the output can be omitted so this can be undefined
+
+  function coerceBool(arg: string) {
+    const value = _.get(argv, arg)
+    const coerced = value === 'true' ? true : value === 'false' ? false : undefined
+    if (coerced !== undefined) {
+      _.set(argv, arg, coerced)
+    }
+  }
+
+  coerceBool('$refOptions.dereference.circular')
 
   const ISGLOB = isGlob(argIn)
   const ISDIR = isDir(argIn)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,3 +1,4 @@
+import $RefParser = require('@apidevtools/json-schema-ref-parser')
 import {whiteBright} from 'cli-color'
 import {JSONSchema4Type, JSONSchema4TypeName} from 'json-schema'
 import {findKey, includes, isPlainObject, map} from 'lodash'
@@ -172,6 +173,16 @@ function parseNonLiteral(
         type: 'UNION'
       })
     case 'REFERENCE':
+      if (schema.$ref === '#') {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const {$ref, ...fixedSchema} = schema
+        return parse(fixedSchema, options, rootSchema, keyName, true, processed, usedNames)
+      }
+      const resolver = new $RefParser()
+      resolver.parse(rootSchema)
+      const resolved = resolver.$refs.get(schema.$ref!)
+      log(whiteBright.bgBlue('parser'), schema.$ref, 'resolved', resolved)
+      return parse(resolved, options, rootSchema, keyName, true, processed, usedNames)
       throw Error(format('Refs should have been resolved by the resolver!', schema))
     case 'STRING':
       return set({

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -7,7 +7,7 @@ export async function dereference(
   schema: JSONSchema,
   {cwd, $refOptions}: {cwd: string; $refOptions: $RefParser.Options}
 ): Promise<JSONSchema> {
-  log(whiteBright.bgGreen('resolver'), schema, cwd)
+  log(whiteBright.bgGreen('resolver'), schema, cwd, $refOptions)
   const parser = new $RefParser()
   return parser.dereference(cwd, schema, $refOptions)
 }


### PR DESCRIPTION
worked to generate typescript definition of eslint's config with the following cli command:
```sh
node -p "s=require('eslint/conf/config-schema'), JSON.stringify(s)" | json2ts -v --\$refOptions.dereference.circular=ignore
```
