### PR TITLE
feat: allow using allOf to create interfaces with extends

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -295,6 +295,7 @@ function generateRawType(ast: AST, options: Options): string {
     case 'TYPE_REFERENCE':
       return generateEnumReference(ast)
     default:
+      error('Standalone name ("title") required for item', ast)
       throw unreachableCase(ast)
   }
 }


### PR DESCRIPTION
when one of the items in an `allOf` has `"tsExtendAllOf": true`, like

```json
{
  "definitions": {
    "A": { "title": "A", "type": "object", "properties": { "a": { "type": "number" } } },
    "B": { "title": "B", "allOf": [
      { "type": "object", "tsExtendAllOf": true, "properties": { "b": { "type": "string" } } },
      { "$ref": "#/definitions/A" }
    ] }
}
```

instead of generating
```ts
interface A { a?: number }
type B = { b?: string } & A
```

it will generate
```ts
interface A { a?: number }
interface B extends A { b?: string }
```