### PR TITLE
feat: allow using allOf to create interfaces with extends

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -295,6 +295,7 @@ function generateRawType(ast: AST, options: Options): string {
     case 'TYPE_REFERENCE':
       return generateEnumReference(ast)
     default:
+      error('Standalone name ("title") required for item', ast)
       throw unreachableCase(ast)
   }
 }


### PR DESCRIPTION
Using `tsExtendAllOf` in an `allOf` will make that generated type an interface that extends the other types in the `allOf`, instead of just intersecting(`&`) them together. 